### PR TITLE
Update LFMTP 2025 page

### DIFF
--- a/workshops/2025/CFP.txt
+++ b/workshops/2025/CFP.txt
@@ -1,0 +1,97 @@
+====================================================================
+
+               Call for papers -- LFMTP 2025
+
+           Logical Frameworks and Meta-Languages:
+                   Theory and Practice
+
+             Birmingham, UK -- July 19th, 2025
+             Affiliated with FSCD 2025
+
+              https://lfmtp.org/workshops/2025
+
+====================================================================
+
+         Abstract submission deadline: May 2nd, 2025
+
+
+Logical frameworks and meta-languages form a common substrate for
+representing, implementing, and reasoning about a wide variety of
+deductive systems of interest in logic and computer science. Their design
+and implementation, and their use in reasoning tasks ranging from the
+correctness of software to the properties of formal computational systems,
+have been the focus of considerable research over the past three decades.
+
+The annual LFMTP workshop brings together designers, implementors, and
+practitioners to discuss various aspects of the structure and utility of
+logical frameworks, including the treatment of variable binding, inductive
+and co-inductive reasoning techniques, and qualitative aspects of
+reasoning including expressivity and lucidity.
+
+LFMTP 2025 will provide researchers a forum to present state-of-the-art
+techniques and discuss progress in areas such as the following:
+
+* Encoding and reasoning about the meta-theory of programming languages,
+  logical systems and related formally specified systems.
+
+* Theoretical and practical issues concerning the treatment of variable
+  binding, especially the representation of, and reasoning about,
+  datatypes defined from binding signatures.
+
+* Logical treatments of inductive and co-inductive definitions and
+  associated reasoning techniques, including inductive types of higher
+  dimension in homotopy type theory
+
+* Graphical languages for building proofs, applications in geometry,
+  equational reasoning and category theory.
+
+* New theory contributions: canonical and substructural frameworks,
+  contextual frameworks, proof-theoretic foundations supporting
+  binders, functional programming over logical frameworks,
+  homotopy and cubical type theory.
+
+* Applications of logical frameworks: proof-carrying architectures,
+  proof exchange and transformation, program refactoring, etc.
+
+* Techniques for programming with binders in functional programming
+  languages such as Haskell, OCaml or Agda, and logic programming
+  languages such as lambda Prolog or Alpha-Prolog.
+
+The workshop's program will include contributed and invited talks.
+
+
+## Important Dates
+
+Abstract submission deadline: May 2, 2025 (AoE)
+Paper submission deadline: May 9, 2025 (AoE)
+Notification to authors: June 6, 2025 (AoE)
+
+## Submission
+
+Submit on EasyChair: https://easychair.org/conferences?conf=lfmtp2025
+
+In addition to regular papers, we welcome/encourage the submission of
+"work in progress" reports, in a broad sense. Those do not need to
+report fully polished research results, but should be of interest for
+the community at large.
+
+Submitted papers should be in PDF, formatted using the EPTCS style
+guidelines. The length is restricted to 15 pages for regular papers and
+8 pages for "Work in Progress" papers.
+
+## Proceedings
+
+A selection of the presented papers will be published online in the
+Electronic Proceedings in Theoretical Computer Science (EPTCS).
+
+## Program Committee
+
+* David Baelde (ENS Rennes, IRISA)
+* Kaustuv Chaudhuri, Co-Chair (Inria)
+* Thaynara A. de Lima (IME, Federal University Goiás, Brazil)
+* Temur Kutsia (RISC, Johannes Kepler University Linz, Austria)
+* Marina Lenisa (University of Udine)
+* Chris Martens (Northeastern University, USA)
+* Daniele Nantes-Sobrinho, Co-Chair (Imperial College London)
+* Giselle Reis (CMU, Qatar)
+* Daniel Ventura (INF, Federal University Goiás, Brazil)

--- a/workshops/2025/index.md
+++ b/workshops/2025/index.md
@@ -1,5 +1,7 @@
 # LFMTP 2025
 
+**July 19, Birmingham, UK, associated with FSCD at [FSCD 2025](https://fscd2025.github.io)**
+
 ## Scope
 
 Logical frameworks and meta-languages form a common substrate for
@@ -14,15 +16,68 @@ utility of logical frameworks, including the treatment of variable
 binding, inductive and co-inductive reasoning techniques and the
 expressiveness and lucidity of the reasoning process.
 
-LFMTP 2024 will provide researchers a forum to present state-of-the-art
+LFMTP 2025 will provide researchers a forum to present state-of-the-art
 techniques and discuss progress in areas such as the following:
 
-- Design, Analysis, Implementation, Evaluation, and Application of logical frameworks like LF, Abella, Beluga, ELPI, Hybrid, lambdaPi, or MMT
-- Encoding and reasoning about the theory of programming languages, logical systems, type theories, and similar formal systems
-- Theoretical and practical issues concerning the treatment of variable binding such as higher-order abstract syntax, nominal logic, explicit substituations, or binding signatures
-- Representation and reasoning about features of logics and languages like equality, inductive and co-inductive definitions, inductive types of higher dimension, universes, as well as associated reasoning techniques
-- Frontiers of logical frameworks such as canonical and substructural frameworks, contextual frameworks, functional programming over logical frameworks, or homotopy and cubical type theory
-- Logical framework-based tools and services such as theorem proving, search tools, or IDEs
-- Two-level languages to program and reason over logics like tactic languages, reflection, or meta-programming in interactive provers such as LTac, ELPI, MetaCoq, Isabelle, and Lean's meta-programming), including implementation and use cases
-- Graphical languages for building proofs, applications in geometry, equational reasoning and category theory.
+- Encoding and reasoning about the meta-theory of programming languages,
+  logical systems and related formally specified systems.
 
+- Theoretical and practical issues concerning the treatment of variable
+  binding, especially the representation of, and reasoning about,
+  datatypes defined from binding signatures.
+
+- Logical treatments of inductive and co-inductive definitions and
+  associated reasoning techniques, including inductive types of higher
+  dimension in homotopy type theory
+
+- Graphical languages for building proofs, applications in geometry,
+  equational reasoning and category theory.
+
+- New theory contributions: canonical and substructural frameworks,
+  contextual frameworks, proof-theoretic foundations supporting
+  binders, functional programming over logical frameworks,
+  homotopy and cubical type theory.
+
+- Applications of logical frameworks: proof-carrying architectures,
+  proof exchange and transformation, program refactoring, etc.
+
+- Techniques for programming with binders in functional programming
+  languages such as Haskell, OCaml or Agda, and logic programming
+  languages such as lambda Prolog or Alpha-Prolog.
+
+The workshop's program will include contributed and invited talks.
+
+## Proceedings
+
+A selection of the presented papers will be published online in the [Electronic Proceedings in Theoretical Computer Science (EPTCS)](https://eptcs.org).
+
+## Program Committee
+
+- David Baelde (ENS Rennes, IRISA)
+- Kaustuv Chaudhuri, Co-Chair (Inria)
+- Thaynara A. de Lima (IME, Federal University Goiás, Brazil)
+- Temur Kutsia (RISC, Johannes Kepler University Linz, Austria)
+- Marina Lenisa (University of Udine)
+- Chris Martens (Northeastern University, USA)
+- Daniele Nantes-Sobrinho, Co-Chair (Imperial College London)
+- Giselle Reis (CMU, Qatar)
+- Daniel Ventura (INF, Federal University Goiás, Brazil)
+
+## Important Dates
+
+- Abstract submission deadline: May    2
+- Paper submission deadline:    May    9
+- Notification to authors:      June   6
+
+## Submission [Call for Papers](https://lfmtp.github.io/lfmtp-page/workshops/2025/CFP.txt)
+
+Submit on EasyChair: https://easychair.org/conferences?conf=lfmtp2025
+
+In addition to regular papers, we welcome/encourage the submission of
+"work in progress" reports, in a broad sense. Those do not need to
+report fully polished research results, but should be of interest for
+the community at large.
+
+Submitted papers should be in PDF, formatted using the [EPTCS style](https://info.eptcs.org/)
+guidelines. The length is restricted to 15 pages for regular papers and
+8 pages for "Work in Progress" papers.


### PR DESCRIPTION
Updated the 2025 page for LFMTP based on information given here: https://lists.seas.upenn.edu/pipermail/types-announce/2025/011849.html and following the general structure of the 2024 page.